### PR TITLE
Development

### DIFF
--- a/assets/javascripts/discourse/controllers/move-post-approval.js.es6
+++ b/assets/javascripts/discourse/controllers/move-post-approval.js.es6
@@ -1,0 +1,145 @@
+import { isEmpty } from "@ember/utils";
+import { alias, equal } from "@ember/object/computed";
+import Controller from "@ember/controller";
+import ModalFunctionality from "discourse/mixins/modal-functionality";
+import DiscourseURL from "discourse/lib/url";
+import { default as computed } from "ember-addons/ember-computed-decorators";
+import { extractError } from "discourse/lib/ajax-error";
+import { ajax } from "discourse/lib/ajax";
+
+export default Controller.extend(ModalFunctionality, {
+    topicName: null,
+    saving: false,
+    categoryId: null,
+    tags: null,
+    canAddTags: alias("site.can_create_tag"),
+    selectedTopicId: null,
+    newTopic: equal("selection", "new_topic"),
+    existingTopic: equal("selection", "existing_topic"),
+    awardBadge: false,
+
+    init() {
+        this._super(...arguments);
+
+        this.saveAttrNames = [
+            "newTopic",
+            "existingTopic"
+        ];
+
+        this.moveTypes = [
+            "newTopic",
+            "existingTopic"
+        ];
+    },
+
+    @computed("saving", "selectedTopicId", "topicName")
+    buttonDisabled(saving, selectedTopicId, topicName) {
+        return saving || (isEmpty(selectedTopicId) && isEmpty(topicName));
+    },
+
+    @computed(
+        "saving",
+        "newTopic",
+        "existingTopic"
+    )
+    buttonTitle(saving, newTopic, existingTopic) {
+        if (newTopic) {
+            return I18n.t("post_approval.modal.topic.title");
+        } else if (existingTopic) {
+            return I18n.t("post_approval.modal.reply.title");
+        } else {
+            return I18n.t("saving");
+        }
+    },
+
+    predictSelection() {
+        const currentTitle = this.get("model.title");
+
+        // TODO: use settings rather than hardcoding this?
+        if (currentTitle.includes("Reply to Topic") || currentTitle.includes("Request to Reply"))
+            return "existing_topic";
+
+        return "new_topic";
+    },
+
+    predictTopicName() {
+        return this.get("model.title"); // TODO: remove any prefix? (infer from settings)
+    },
+
+    predictCategoryId() {
+        return null; // TODO: prepopulate from title? (infer from title + settings)
+    },
+
+    predictSelectedTopicId() {
+        return null; // TODO: predict selected topic for replies? (how?)
+    },
+
+    onShow() {
+        const currentName = this.get("model.title");
+
+        this.setProperties({
+            "modal.modalClass": "post-approval-modal",
+            saving: false,
+            selection: this.predictSelection(),
+            topicName: this.predictTopicName(),
+            categoryId: this.predictCategoryId(),
+            selectedTopicId: this.predictSelectedTopicId(),
+            tags: null
+        });
+    },
+
+    actions: {
+        completePostApproval() {
+            this.moveTypes.forEach(type => {
+                if (this.get(type)) {
+                    this.send("movePostTo", type);
+                }
+            });
+        },
+
+        movePostTo(type) {
+            this.set("saving", true);
+            const topicId = this.get("model.id");
+            let options;
+
+            if (type === "existingTopic") {
+                options = {
+                    pm_topic_id: topicId,
+                    target_topic_id: this.selectedTopicId,
+                    award_badge: this.awardBadge
+                };
+            } else if (type === "newTopic") {
+                options = {
+                    pm_topic_id: topicId,
+                    title: this.topicName,
+                    target_category_id: this.categoryId,
+                    tags: this.tags,
+                    award_badge: this.awardBadge
+                };
+            }
+
+            const promise = ajax("/post-approval", {
+                data: options,
+                cache: false,
+                type: "POST"
+            });
+
+            promise
+                .then(result => {
+                    this.send("closeModal");
+                    DiscourseURL.routeTo(result.url);
+                })
+                .catch(xhr => {
+                    if (type === "existingTopic")
+                        this.flash(extractError(xhr, I18n.t("post_approval.modal.reply.error")));
+                    else
+                        this.flash(extractError(xhr, I18n.t("post_approval.modal.topic.error")));
+                })
+                .finally(() => {
+                    this.set("saving", false);
+                });
+
+            return false;
+        }
+    }
+});

--- a/assets/javascripts/discourse/initializers/post-approval-edit.js.es6
+++ b/assets/javascripts/discourse/initializers/post-approval-edit.js.es6
@@ -1,0 +1,23 @@
+import { withPluginApi } from 'discourse/lib/plugin-api';
+import showModal from "discourse/lib/show-modal";
+
+export default {
+    name: 'post-approval-edits',
+
+    initialize() {
+        withPluginApi('0.8.13', api => {
+
+            api.modifyClass('route:topic', {
+                actions: {
+                    movePostApproval() {
+                        showModal("move-post-approval", {
+                            model: this.modelFor("topic"),
+                            title: "post_approval.modal.title"
+                        });
+                    },
+                }
+            });
+
+        });
+    }
+};

--- a/assets/javascripts/discourse/templates/connectors/category-custom-settings/post-approval-category-settings.hbs
+++ b/assets/javascripts/discourse/templates/connectors/category-custom-settings/post-approval-category-settings.hbs
@@ -1,27 +1,36 @@
-<section class='field'>
-  <label>
-    {{input type="checkbox" checked=category.custom_fields.pa_redirect_topic_enabled}}
-    {{i18n 'post_approval.redirect.topic.enabled'}}
-  </label>
-</section>
+{{#if siteSettings.post_approval_enabled }}
+  {{#if siteSettings.post_approval_redirect_enabled }}
+    <section>
+      <h3> {{i18n "post_approval.settings.title"}}</h3>
 
-<section class='field'>
-  <label>
-    {{i18n 'post_approval.redirect.topic.message'}}
-  </label>
-  {{d-editor value=category.custom_fields.pa_redirect_topic_message}}
-</section>
+      <section class='field'>
+        <label>
+          {{input type="checkbox" checked=category.custom_fields.pa_redirect_topic_enabled}}
+          {{i18n 'post_approval.settings.redirect.topic.enabled'}}
+        </label>
+      </section>
 
-<section class='field'>
-  <label>
-    {{input type="checkbox" checked=category.custom_fields.pa_redirect_reply_enabled}}
-    {{i18n 'post_approval.redirect.reply.enabled'}}
-  </label>
-</section>
+      <section class='field'>
+        <label>
+          {{input type="checkbox" checked=category.custom_fields.pa_redirect_reply_enabled}}
+          {{i18n 'post_approval.settings.redirect.reply.enabled'}}
+        </label>
+      </section>
 
-<section class='field'>
-  <label>
-    {{i18n 'post_approval.redirect.reply.message'}}
-  </label>
-  {{d-editor value=category.custom_fields.pa_redirect_reply_message}}
-</section>
+      <section class='field'>
+        <label>
+          {{i18n 'post_approval.settings.redirect.topic.message'}}
+        </label>
+        {{d-editor value=category.custom_fields.pa_redirect_topic_message}}
+      </section>
+
+      <section class='field'>
+        <label>
+          {{i18n 'post_approval.settings.redirect.reply.message'}}
+        </label>
+        {{d-editor value=category.custom_fields.pa_redirect_reply_message}}
+      </section>
+
+    </section>
+  {{/if}}
+{{/if}}

--- a/assets/javascripts/discourse/templates/connectors/category-custom-settings/post-approval-category-settings.hbs
+++ b/assets/javascripts/discourse/templates/connectors/category-custom-settings/post-approval-category-settings.hbs
@@ -1,0 +1,27 @@
+<section class='field'>
+  <label>
+    {{input type="checkbox" checked=category.custom_fields.pa_redirect_topic_enabled}}
+    {{i18n 'post_approval.redirect.topic.enabled'}}
+  </label>
+</section>
+
+<section class='field'>
+  <label>
+    {{i18n 'post_approval.redirect.topic.message'}}
+  </label>
+  {{d-editor value=category.custom_fields.pa_redirect_topic_message}}
+</section>
+
+<section class='field'>
+  <label>
+    {{input type="checkbox" checked=category.custom_fields.pa_redirect_reply_enabled}}
+    {{i18n 'post_approval.redirect.reply.enabled'}}
+  </label>
+</section>
+
+<section class='field'>
+  <label>
+    {{i18n 'post_approval.redirect.reply.message'}}
+  </label>
+  {{d-editor value=category.custom_fields.pa_redirect_reply_message}}
+</section>

--- a/assets/javascripts/discourse/templates/connectors/connectors/topic-footer-main-buttons-before-create/post-approval-button.hbs
+++ b/assets/javascripts/discourse/templates/connectors/connectors/topic-footer-main-buttons-before-create/post-approval-button.hbs
@@ -1,10 +1,12 @@
-{{#if showAdminButton}}
-    {{d-button
-        id="topic-footer-button-post-approval"
-        class="btn-default topic-footer-button standard btn btn-icon-text ember-view"
-        action=toggleArchived
-        icon="clipboard-check"
-        translatedLabel="topic.post_approval.title"
-        translatedTitle="topic.post_approval.help"
-    }}
+{{#if currentUser.is_post_approval}}
+    {{#if topic.isPrivateMessage}}
+        {{d-button
+            id="topic-footer-button-post-approval"
+            class="btn-default topic-footer-button standard btn btn-icon-text ember-view"
+            action=(route-action "movePostApproval")
+            icon="check"
+            label="post_approval.button.title"
+            title="post_approval.button.help"
+        }}
+    {{/if}}
 {{/if}}

--- a/assets/javascripts/discourse/templates/connectors/connectors/topic-footer-main-buttons-before-create/post-approval-button.hbs
+++ b/assets/javascripts/discourse/templates/connectors/connectors/topic-footer-main-buttons-before-create/post-approval-button.hbs
@@ -1,0 +1,10 @@
+{{#if showAdminButton}}
+    {{d-button
+        id="topic-footer-button-post-approval"
+        class="btn-default topic-footer-button standard btn btn-icon-text ember-view"
+        action=toggleArchived
+        icon="clipboard-check"
+        translatedLabel="topic.post_approval.title"
+        translatedTitle="topic.post_approval.help"
+    }}
+{{/if}}

--- a/assets/javascripts/discourse/templates/modal/move-post-approval.hbs
+++ b/assets/javascripts/discourse/templates/modal/move-post-approval.hbs
@@ -1,0 +1,52 @@
+{{#d-modal-body id='move-post-approval'}}
+
+    <div class="radios">
+        <label class="radio-label" for="move-to-new-topic">
+            {{radio-button id='move-to-new-topic' name="move-to-entity" value="new_topic" selection=selection}}
+            <b>{{i18n 'post_approval.modal.topic.radio_label'}}</b>
+        </label>
+
+        <label class="radio-label" for="move-to-existing-topic">
+            {{radio-button id='move-to-existing-topic' name="move-to-entity" value="existing_topic" selection=selection}}
+            <b>{{i18n 'post_approval.modal.reply.radio_label'}}</b>
+        </label>
+
+    </div>
+
+    {{#if existingTopic}}
+        <p>{{{i18n 'post_approval.modal.reply.instructions' count=1}}}</p>
+        <form>
+            {{choose-topic currentTopicId=model.id selectedTopicId=selectedTopicId}}
+        </form>
+    {{/if}}
+
+    {{#if newTopic}}
+        <p>{{{i18n 'post_approval.modal.topic.instructions' count=1}}}</p>
+        <form>
+            <label>{{i18n 'post_approval.modal.topic.topic_name'}}</label>
+            {{text-field value=topicName placeholderKey="composer.title_placeholder" elementId='split-topic-name'}}
+
+            <label>{{i18n 'categories.category'}}</label>
+            {{category-chooser value=categoryId class="small"}}
+
+            {{#if canAddTags}}
+                <label>{{i18n 'tagging.tags'}}</label>
+                {{tag-chooser tags=tags filterable=true categoryId=categoryId}}
+            {{/if}}
+        </form>
+    {{/if}}
+
+    <div>
+        <label>
+            {{input type="checkbox" checked=awardBadge }}
+            {{i18n 'post_approval.modal.badge.title'}}
+        </label>
+    </div>
+
+{{/d-modal-body}}
+
+<div class="modal-footer">
+    {{#d-button class="btn-primary" disabled=buttonDisabled action=(action "completePostApproval")}}
+        {{d-icon "check"}} {{buttonTitle}}
+    {{/d-button}}
+</div>

--- a/assets/stylesheets/common/base/post-approval-modal.scss
+++ b/assets/stylesheets/common/base/post-approval-modal.scss
@@ -1,0 +1,16 @@
+// post approval modal
+.post-approval-modal {
+  // move to existing topic
+  .existing-topic {
+    .radio {
+      flex-wrap: wrap;
+    }
+    .topic-title {
+      max-width: 90%;
+    }
+    .topic-categories {
+      width: 100%;
+    }
+  }
+}
+  

--- a/assets/stylesheets/desktop/post-approval-modal.scss
+++ b/assets/stylesheets/desktop/post-approval-modal.scss
@@ -1,0 +1,56 @@
+.post-approval-modal {
+  .modal-body {
+    position: relative;
+    height: 350px;
+  }
+
+  #move-post-approval {
+    // prevents content from moving when user selects different move options 525px
+    // is the same width we set on category edit modal
+    width: 525px;
+
+    p {
+      margin-top: 0;
+    }
+
+    .radios {
+      margin-bottom: 10px;
+      display: flex;
+      flex-direction: row;
+
+      .radio-label {
+        display: inline-block;
+        padding-right: 15px;
+      }
+    }
+
+    button {
+      margin-top: 10px;
+      display: block;
+      width: 300px;
+    }
+
+    .category-chooser {
+      margin-bottom: 9px;
+    }
+
+    form {
+      width: 95%;
+      margin-top: 20px;
+      #split-topic-name,
+      #choose-topic-title,
+      #choose-message-title {
+        width: 100%;
+      }
+
+      .participant-selector {
+        width: 100%;
+      }
+
+      div.ac-wrap {
+        width: 100%;
+        margin-bottom: 9px;
+      }
+    }
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,10 +1,17 @@
 en:
-  site_settings:
-    post_approval_finish_enabled: "Enable the post approval completion button"
-    post_approval_finish_from_category: "Category that post approval requests are in"
-    post_approval_finish_group: "Group that can finish post approval requests"
-    post_approval_finish_badge: "Badge to award for passing post approval"
-    post_approval_finish_topic_template: "Message for topic approval requests"
-    post_approval_finish_topic_template_alt: "Message for unnecessary topic approval requests"
-    post_approval_finish_reply_template: "Message for reply approval requests"
-    post_approval_finish_reply_template_alt: "Message for unnecessary reply approval requests"
+  js:
+    topic:
+      post_approval:
+        title: "Approve Post"
+        help: "Complete post approval procedure on this post"
+  admin_js:
+    admin:
+      site_settings:
+        post_approval_finish_enabled: "Enable the post approval completion button"
+        post_approval_finish_from_category: "Category that post approval requests are in"
+        post_approval_finish_group: "Group that can finish post approval requests"
+        post_approval_finish_badge: "Badge to award for passing post approval"
+        post_approval_finish_topic_template: "Message for topic approval requests"
+        post_approval_finish_topic_template_alt: "Message for unnecessary topic approval requests"
+        post_approval_finish_reply_template: "Message for reply approval requests"
+        post_approval_finish_reply_template_alt: "Message for unnecessary reply approval requests"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -24,7 +24,7 @@ en:
           topic_name: "New Topic Title"
           radio_label: "As New Topic"
         reply:
-          error: "There was an error moving posts into that topic."
+          error: "There was an error creating the reply."
           instructions: "Please choose the topic you'd like to move this request to as a reply."
           title: "Approve as Reply To Topic"
           radio_label: "As Reply To Topic"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4,6 +4,15 @@ en:
       button:
         title: "Approve Post"
         help: "Complete Post Approval procedure on this post"
+      settings:
+        title: "Post Approval"
+        redirect:
+          topic:
+            enabled: "Redirect new topics by low trust levels to post approval?"
+            message: "Message to send along when redirecting new topics"
+          reply:
+            enabled: "Redirect replies by low trust levels to post approval?"
+            message: "Message to send along when redirecting new topics"
       modal:
         badge:
           title: "Award Post Approval badge for this post"
@@ -19,10 +28,3 @@ en:
           instructions: "Please choose the topic you'd like to move this request to as a reply."
           title: "Approve as Reply To Topic"
           radio_label: "As Reply To Topic"
-      redirect:
-        topic:
-          enabled: "Redirect new topics by low trust levels to post approval?"
-          message: "Message to send along when redirecting new topics"
-        reply:
-          enabled: "Redirect replies by low trust levels to post approval?"
-          message: "Message to send along when redirecting new topics"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,17 +1,28 @@
 en:
   js:
-    topic:
-      post_approval:
+    post_approval:
+      button:
         title: "Approve Post"
-        help: "Complete post approval procedure on this post"
-  admin_js:
-    admin:
-      site_settings:
-        post_approval_finish_enabled: "Enable the post approval completion button"
-        post_approval_finish_from_category: "Category that post approval requests are in"
-        post_approval_finish_group: "Group that can finish post approval requests"
-        post_approval_finish_badge: "Badge to award for passing post approval"
-        post_approval_finish_topic_template: "Message for topic approval requests"
-        post_approval_finish_topic_template_alt: "Message for unnecessary topic approval requests"
-        post_approval_finish_reply_template: "Message for reply approval requests"
-        post_approval_finish_reply_template_alt: "Message for unnecessary reply approval requests"
+        help: "Complete Post Approval procedure on this post"
+      modal:
+        badge:
+          title: "Award Post Approval badge for this post"
+        title: "Post Approval"
+        topic:
+          error: "There was an error creating the new topic."
+          instructions: "You are about to complete this request by creating it as a new topic."
+          title: "Approve as New Topic"
+          topic_name: "New Topic Title"
+          radio_label: "As New Topic"
+        reply:
+          error: "There was an error moving posts into that topic."
+          instructions: "Please choose the topic you'd like to move this request to as a reply."
+          title: "Approve as Reply To Topic"
+          radio_label: "As Reply To Topic"
+      redirect:
+        topic:
+          enabled: "Redirect new topics by low trust levels to post approval?"
+          message: "Message to send along when redirecting new topics"
+        reply:
+          enabled: "Redirect replies by low trust levels to post approval?"
+          message: "Message to send along when redirecting new topics"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,0 +1,20 @@
+en:
+  site_settings:
+    post_approval_enabled: "Enable Post Approval procedure"
+
+    post_approval_badge: "Badge to award as part of Post Approval"
+
+    post_approval_redirect_enabled: "Enable Post Approval redirection"
+    post_approval_redirect_tl_max: "Max trust level that Post Approval redirection applies to"
+    post_approval_redirect_group: "Group to send Post Approval messages to"
+    post_approval_redirect_topic_prefix: "Prefix for messages to Post Approval for topics"
+    post_approval_redirect_reply_prefix: "Prefix for messages to Post Approval for replies"
+
+    post_approval_button_enabled: "Enable button to finish Post Approval requests"
+    post_approval_button_group: "Group that can use button to finish Post Approval requests"
+    
+    post_approval_response_topic: "Message for topics approved through Post Approval"
+    post_approval_response_reply: "Message for replies approved through Post Approval"
+    post_approval_response_badge: "Message to indicate user received Post Approval badge for this request"
+    post_approval_response_topic_footer: "Message to tell user they could post topic without Post Approval"
+    post_approval_response_reply_footer: "Message to tell user they could post reply without Post Approval"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,12 +1,14 @@
 plugins:
   post_approval_enabled:
     default: true
+    client: true
 
   post_approval_badge:
     default: 0
 
   post_approval_redirect_enabled:
     default: true
+    client: true
   post_approval_redirect_tl_max:
     default: 1
   post_approval_redirect_group:
@@ -18,8 +20,10 @@ plugins:
 
   post_approval_button_enabled:
     default: true
+    client: true
   post_approval_button_group:
     default: "Community_Sage"
+    client: true
 
   post_approval_response_topic:
     default: "Thanks for your contribution! Your topic has been **approved** for **%CATEGORY%** here:\n%POST%"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,28 +1,33 @@
 plugins:
-  post_approval_finish_enabled:
+  post_approval_enabled:
     default: true
 
-  post_approval_finish_from_category:
-    type: category
+  post_approval_badge:
     default: 0
 
-  post_approval_finish_group:
+  post_approval_redirect_enabled:
+    default: true
+  post_approval_redirect_tl_max:
+    default: 1
+  post_approval_redirect_group:
+    default: "Post_Approval"
+  post_approval_redirect_topic_prefix:
+    default: "%s > "
+  post_approval_redirect_reply_prefix:
+    default: "Reply to Topic > "
+
+  post_approval_button_enabled:
+    default: true
+  post_approval_button_group:
     default: "Community_Sage"
 
-  post_approval_finish_badge:
-    default: -1
-
-  post_approval_finish_text_topic:
-    default: "Thanks for your contribution. Your topic has been approved and moved to the %CATEGORY% category:\n%POST%"
-
-  post_approval_finish_text_reply:
-    default: "Thanks for your contribution. Your post has been approved as a reply to an existing topic:\n%POST%"
-
-  post_approval_finish_text_badge:
-    default: "Since you blazed through post approval for this post, we also awarded you the %BADGE% badge for this post! Well done!"
-
-  post_approval_finish_text_topic_footer:
-    default: "PS: You don't have to go through post approval for the %CATEGORY% category, so feel free to post there directly on your own next time!"
-
-  post_approval_finish_text_reply_footer:
-    default: "PS: You don't have to go through post approval for this topic, since you already have reply permissions to it / its category, so feel free to reply to it on your own next time!"
+  post_approval_response_topic:
+    default: "Thanks for your contribution! Your topic has been **approved** for **%CATEGORY%** here:\n%POST%"
+  post_approval_response_reply:
+    default: "Thanks for your contribution! Your post has been **approved** as **reply** to an existing topic here:\n%POST%"
+  post_approval_response_badge:
+    default: "🥇 Since you blazed through post approval, you got the %BADGE% badge for this post! Well done!"
+  post_approval_response_topic_footer:
+    default: "PS: You don't have to go through post approval for the %CATEGORY% category, so you can post there directly on your own in the future!"
+  post_approval_response_reply_footer:
+    default: "PS: You already have the required trust level to reply to this topic yourself, so you can post there directly on your own in the future without going through post approval!"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,14 +10,19 @@ plugins:
     default: "Community_Sage"
 
   post_approval_finish_badge:
-    default: 0
+    default: -1
 
-  post_approval_finish_topic_template:
-    default: "Hey %USER%, we have reviewed your topic and have approved it for the %CATEGORYNAME% category.\n\nYour topic has been cloned into the category. You can find the new topic here:\n%TOPICLINK%\n\nThank you for your contribution to the Developer Forum, we really appreciate it!"
-  post_approval_finish_topic_template_unnecessary:
-    default: "Hey %USER%, your topic seems most appropriate for the %CATEGORYNAME% category, which you do not need to use post approval for, since you can create topics there directly.\n\nHowever, to save you some work having to repost it, we have moved it to %CATEGORYNAME% for you. You can find the topic here:\n%TOPICLINK%\n\nThanks and let us know if you have any questions!"
+  post_approval_finish_text_topic:
+    default: "Thanks for your contribution. Your topic has been approved and moved to the %CATEGORY% category:\n%POST%"
 
-  post_approval_finish_reply_template:
-    default: "" # TODO
-  post_approval_finish_reply_template_unnecessary:
-    default: "" # TODO
+  post_approval_finish_text_reply:
+    default: "Thanks for your contribution. Your post has been approved as a reply to an existing topic:\n%POST%"
+
+  post_approval_finish_text_badge:
+    default: "Since you blazed through post approval for this post, we also awarded you the %BADGE% badge for this post! Well done!"
+
+  post_approval_finish_text_topic_footer:
+    default: "PS: You don't have to go through post approval for the %CATEGORY% category, so feel free to post there directly on your own next time!"
+
+  post_approval_finish_text_reply_footer:
+    default: "PS: You don't have to go through post approval for this topic, since you already have reply permissions to it / its category, so feel free to reply to it on your own next time!"

--- a/plugin.rb
+++ b/plugin.rb
@@ -118,8 +118,7 @@ after_initialize do
       return unless SiteSetting.post_approval_finish_badge > 0 # not enabled
       return unless badge = Badge.find_by(id: SiteSetting.post_approval_finish_badge, enabled: true) # no badge found
 
-      # TODO award badge here
-
+      BadgeGranter.grant(badge, post.user, post_id: post.id)
     end
 
     # Whether post could have been posted without post approval

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,5 +1,5 @@
 # name: post-approval-finish
-# version: 0.0.1
+# version: 0.0.2
 # authors: boyned/Kampfkarren, buildthomas
 
 # enabled_site_setting :post_approval_finish_enabled
@@ -18,54 +18,83 @@ after_initialize do
         .where(user_id: current_user.id)
         .exists?
 
-      bb_topic = Topic.find_by(id: params[:bb_topic_id])
+      # Validate post approval PM
       pm_topic = Topic.find_by(id: params[:pm_topic_id], archetype: Archetype.private_message)
-      category = Category.find_by(id: params[:category_id])
-
-      raise Discourse::InvalidParameters.new(:bb_topic_id) unless bb_topic
       raise Discourse::InvalidParameters.new(:pm_topic_id) unless pm_topic
-      raise Discourse::InvalidParameters.new(:category_id) unless category
 
-      post = PostCreator.create(
-        bb_topic.user,
-        category: category.id,
-        title: bb_topic.title,
-        raw: bb_topic.posts.first.raw,
-        user: bb_topic.user,
-        skip_validations: true, # They've already gone through the validations to make the topic first
-      )
+      # TODO: need to validate that current_user can access this PM
 
-      PostAction.where(
-        post: bb_topic.posts.first,
-        post_action_type_id: PostActionType.types[:like],
-      ).each do |action|
-        PostActionCreator.create(action.user, post, :like)
+      # Validate whether badge should be awarded
+      award_badge = params[:award_badge] || false
+      raise Discourse::InvalidParameters.new(:title) unless ([true, false].include?(award_badge))
+
+      if (params[:target_category_id] != nil)
+
+        # Validate target category for new topic
+        target_category = Category.find_by(id: params[:target_category_id])
+        raise Discourse::InvalidParameters.new(:target_category_id) unless target_category
+
+        # TODO: need to validate that current_user can post in this category
+
+        # Validate title for the new topic
+        title = params[:title]
+        raise Discourse::InvalidParameters.new(:title) unless (title.instance_of?(String) &&
+          title.length >= SiteSetting.min_topic_title_length && title.length <= SiteSetting.max_topic_title_length)
+
+        # Validate tags for the new topic
+        tags = params[:tags] == nil ? [] : params[:tags]
+        raise Discourse::InvalidParameters.new(:tags) unless (tags.kind_of?(Array) &&
+          tags.select{|s| !s.instance_of?(String) || s.length == 0}.length > 0) # All strings, non-empty
+
+        # Create the new topic in the target category
+        post = PostCreator.create(
+          pm_topic.user,
+          category: target_category.id,
+          title: title,
+          raw: pm_topic.posts.first.raw,
+          user: pm_topic.user,
+          tags: tags,
+          custom_fields: {
+            post_approval_finished: true # Make sure it triggers notifications
+          }
+          skip_validations: true, # They've already gone through the validations to make the topic first
+        )
+
+        # Complete the request
+        finalize(current_user, pm_topic, post, should_award_badge)
+
+      elsif (params[:target_topic_id] != nil)
+
+        # Validate target existing topic for new reply
+        target_topic = Topic.find_by(id: params[:target_topic_id], Archetype.default)
+        raise Discourse::InvalidParameters.new(:target_topic_id) unless target_topic
+
+        # TODO: need to validate that current_user can reply to this topic
+
+        # Create the new reply on the target topic
+        post = PostCreator.create(
+          pm_topic.user,
+          topic_id: pm_topic.id,
+          raw: pm_topic.posts.first.raw,
+          user: pm_topic.user,
+          custom_fields: {
+            post_approval_finished: true # Make sure it triggers notifications
+          }
+          skip_validations: true, # They've already gone through the validations to make the reply first
+        )
+
+        # Complete the request
+        finalize(current_user, pm_topic, post, should_award_badge)
+
+      else
+        raise Discourse::InvalidParameters.new() # Can't do both a new topic / a reply at once
       end
 
-      # Confirmation message
-      post = PostCreator.create(
-        current_user,
-        topic_id: pm_topic.id,
-        raw: SiteSetting.post_approval_finish_topic_template
-          .gsub("%USER%", bb_topic.user.username)
-          .gsub("%CATEGORYNAME%", category.name)
-          .gsub("%TOPICLINK%", post.topic.url),
-        skip_validations: true,
-      )
-
-      DiscourseSolved.accept_answer!(post, current_user)
-
-      archive_message(post.topic)
-      post.topic.reload
-      post.topic.save
-
-      PostDestroyer.new(Discourse.system_user, bb_topic.posts.first).destroy
-
+      # No error encountered
       render json: success_json
     end
 
-    # Copies and pasted from TopicsController.
-    # Discourse does not provide a method to archive the message.
+    # Archiving a private message
     def archive_message(topic)
       group_id = nil
 
@@ -82,6 +111,73 @@ after_initialize do
       if topic.allowed_users.include?(current_user)
         UserArchivedMessage.archive!(current_user.id, topic)
       end
+    end
+
+    # Awarding the post approval badge for a post
+    def award_badge(post)
+      return unless SiteSetting.post_approval_finish_badge > 0 # not enabled
+      return unless badge = Badge.find_by(id: SiteSetting.post_approval_finish_badge, enabled: true) # no badge found
+
+      # TODO award badge here
+
+    end
+
+    # Whether post could have been posted without post approval
+    def could_post_on_own(post)
+
+      # TODO
+      
+      return false
+    end
+
+    # Getting the body for the final reply to the private message
+    def make_body(post, should_award_badge)
+
+      # Different entry text depending on whether it was a new topic / a reply
+      is_topic = post.is_first_post?
+      body = (is_topic ? SiteSetting.post_approval_finish_text_topic : SiteSetting.post_approval_finish_text_reply)
+
+      # Attach a note if the user achieved a badge through this post approval request
+      if should_award_badge
+        body += "\n\n" + SiteSetting.post_approval_finish_text_badge
+      end
+
+      # Attach a note if the user could have posted without post approval
+      if could_post_on_own(post)
+        body += "\n\n" + (is_topic ? SiteSetting.post_approval_finish_text_topic_footer : SiteSetting.post_approval_finish_text_reply_footer)
+      end
+
+    end
+
+    # Collection of actions to perform upon finalizing post approval
+    def finalize(current_user, pm_topic, post, should_award_badge)
+
+      # Award badge if applicable
+      award_badge(post) if should_award_badge
+
+      # Format body depending on input post
+      body = make_body(post, should_award_badge)
+        .gsub("%USER%", pm_topic.user.username)
+        .gsub("%POST%", post.url)
+      body = body.gsub("%CATEGORY%", post.category.name) if post.category
+
+      # Send confirmation on private message
+      reply = PostCreator.create(
+        current_user,
+        topic_id: pm_topic.id,
+        raw: body,
+        skip_validations: true,
+      )
+
+      # Mark confirmation as solution of private message
+      DiscourseSolved.accept_answer!(reply, current_user)
+
+      # Archive the private message
+      archive_message(pm_topic)
+
+      pm_topic.reload
+      pm_topic.save
+
     end
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -323,6 +323,7 @@ after_initialize do
   end
 
   # Showing users whether they are post approval members
+  # TODO: the following could just be made entirely client-sided
 
   add_to_serializer(:current_user, :is_post_approval) {
     group = Group.find_by(name: SiteSetting.post_approval_button_group)

--- a/plugin.rb
+++ b/plugin.rb
@@ -67,7 +67,7 @@ after_initialize do
       return SiteSetting.post_approval_enabled &&
         SiteSetting.post_approval_redirect_enabled &&
         SiteSetting.post_approval_redirect_group.present? &&
-        !(topic.custom_fields["post_approval"]) && # TODO: test+fix this, custom marker to fall-through
+        !(topic.custom_fields["post_approval"]) && # suppress notifications unless post was already approved
         topic.user&.trust_level <= SiteSetting.post_approval_redirect_tl_max &&
         topic.category&.pa_redirect_topic_enabled
     end
@@ -205,7 +205,7 @@ after_initialize do
           user: pm_topic.user,
           tags: tags,
           custom_fields: {
-            post_approval: true # TODO: does this work? Make sure it triggers notifications
+            post_approval: true # marker to let ourselves know not to suppress notifications
           },
           skip_validations: true, # They've already gone through the validations to make the topic first
         )

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,40 +1,185 @@
-# name: post-approval-finish
-# version: 0.0.2
+# name: post-approval
+# version: 0.1.0
 # authors: boyned/Kampfkarren, buildthomas
 
-# enabled_site_setting :post_approval_finish_enabled
+enabled_site_setting :post_approval_enabled
+
+register_asset "stylesheets/common/base/post-approval-modal.scss"
+register_asset "stylesheets/desktop/post-approval-modal.scss", :desktop
 
 after_initialize do
-  module ::PostApprovalFinish
-    class Engine < ::Rails::Engine
-      engine_name "post_approval_finish"
-      isolate_namespace PostApprovalFinish
+
+  # Extend categories with extra properties
+
+  require_dependency "category"
+
+  Site.preloaded_category_custom_fields << "pa_redirect_topic_enabled"
+  Site.preloaded_category_custom_fields << "pa_redirect_topic_message"
+  Site.preloaded_category_custom_fields << "pa_redirect_reply_enabled"
+  Site.preloaded_category_custom_fields << "pa_redirect_reply_message"
+
+  register_category_custom_field_type("pa_redirect_topic_enabled", :boolean)
+  register_category_custom_field_type("pa_redirect_topic_message", :text)
+  register_category_custom_field_type("pa_redirect_reply_enabled", :boolean)
+  register_category_custom_field_type("pa_redirect_reply_message", :text)
+
+  class ::Category
+    def pa_redirect_topic_enabled
+      self.custom_fields["pa_redirect_topic_enabled"]
+    end
+
+    def pa_redirect_topic_message
+      self.custom_fields["pa_redirect_topic_message"]
+    end
+    
+    def pa_redirect_reply_enabled
+      self.custom_fields["pa_redirect_reply_enabled"]
+    end
+
+    def pa_redirect_reply_message
+      self.custom_fields["pa_redirect_reply_message"]
     end
   end
 
-  class PostApprovalFinish::PostApprovalFinishController < ::ApplicationController
+  add_to_serializer(:basic_category, :pa_redirect_topic_enabled) { object.pa_redirect_topic_enabled }
+  add_to_serializer(:basic_category, :pa_redirect_topic_message) { object.pa_redirect_topic_message }
+  add_to_serializer(:basic_category, :pa_redirect_reply_enabled) { object.pa_redirect_reply_enabled }
+  add_to_serializer(:basic_category, :pa_redirect_reply_message) { object.pa_redirect_reply_message }
+
+  # Prevent low TLs from editing topics into redirected categories
+
+  module GuardianInterceptor
+    def can_move_topic_to_category?(category)
+      if SiteSetting.post_approval_enabled && SiteSetting.post_approval_redirect_enabled
+        category = Category === category ? category : Category.find(category || SiteSetting.uncategorized_category_id)
+
+        return false if (category.pa_redirect_topic_enabled && user.trust_level <= SiteSetting.post_approval_redirect_tl_max)
+      end
+      super(category)
+    end
+  end
+  Guardian.send(:prepend, GuardianInterceptor)
+
+  # Prevent first post notifications on topics that are about to be redirected
+
+  module PostAlerterInterceptor
+    def is_redirectable(topic)
+      return SiteSetting.post_approval_enabled &&
+        SiteSetting.post_approval_redirect_enabled &&
+        SiteSetting.post_approval_redirect_group.present? &&
+        !(topic.custom_fields["post_approval"]) && # TODO: test+fix this, custom marker to fall-through
+        topic.user&.trust_level <= SiteSetting.post_approval_redirect_tl_max &&
+        topic.category&.pa_redirect_topic_enableds
+    end
+    module_function :is_redirectable
+
+    def after_save_post(post, new_record)
+      # Do not pass to super if this is a post that is about to be redirected
+      super(post, new_record) unless (post.is_first_post? &&
+        PostAlerterInterceptor.is_redirectable(post.topic))
+    end
+  end
+  PostAlerter.send(:prepend, PostAlerterInterceptor)
+
+  # Redirect topics on creation
+
+  DiscourseEvent.on(:topic_created) do |topic|
+    # Only proceed if the topic needs to be redirected
+    next unless PostAlerterInterceptor.is_redirectable(topic)
+
+    # Find post approval team group
+    group = Group.lookup_group(SiteSetting.post_approval_redirect_group)
+
+    # Turn it into a private message
+    request_category = topic.category
+    TopicConverter.new(topic, Discourse.system_user).convert_to_private_message
+
+    # Turn first post into wiki and include category in title
+    topic.first_post.revise(
+      Discourse.system_user,
+      title: (SiteSetting.post_approval_redirect_topic_prefix % [request_category.name]) + topic.title,
+      wiki: true,
+      bypass_rate_limiter: true,
+      skip_validations: true
+    )
+    topic.first_post.reload
+    
+    topic.save
+    topic.reload
+
+    # Give system response to the message with details
+    PostCreator.create(Discourse.system_user,
+      raw: request_category.pa_redirect_topic_message,
+      topic_id: topic.id,
+      wiki: true,
+      skip_validations: true)
+
+    # Invite post approval
+    TopicAllowedGroup.create!(topic_id: topic.id, group_id: group.id)
+
+    # Send invite notification to post approval team members
+    group.users.where(
+      "group_users.notification_level in (:levels) AND user_id != :id",
+      levels: [NotificationLevels.all[:watching], NotificationLevels.all[:watching_first_post]],
+      id: topic.user.id
+    ).find_each do |u|
+
+      u.notifications.create!(
+        notification_type: Notification.types[:invited_to_private_message],
+        topic_id: topic.id,
+        post_number: 1,
+        data: {
+          topic_title: topic.title,
+          display_username: topic.user.username,
+          group_id: group.id
+        }.to_json
+      )
+    end
+  end
+
+  # Post approval completion endpoint
+
+  module ::PostApproval
+    class Engine < ::Rails::Engine
+      engine_name "post_approval"
+      isolate_namespace PostApproval
+    end
+  end
+
+  class PostApproval::PostApprovalController < ::ApplicationController
+    def to_bool(value)
+      return true   if value == true   || value =~ (/(true|t|yes|y|1)$/i)
+      return false  if value == false  || value.blank? || value =~ (/(false|f|no|n|0)$/i)
+
+      return nil # invalid
+    end
+
     def action
-      raise Discourse::InvalidAccess unless GroupUser.where(group_id: Group.find_by(name: SiteSetting.post_approval_finish_group).id)
+      raise Discourse::NotFound.new unless SiteSetting.post_approval_enabled &&
+        SiteSetting.post_approval_button_enabled
+      
+      raise Discourse::InvalidAccess.new unless GroupUser.where(group_id: Group.find_by(name: SiteSetting.post_approval_button_group).id)
         .where(user_id: current_user.id)
         .exists?
 
       # Validate post approval PM
       pm_topic = Topic.find_by(id: params[:pm_topic_id], archetype: Archetype.private_message)
-      raise Discourse::InvalidParameters.new(:pm_topic_id) unless pm_topic
-
-      # TODO: need to validate that current_user can access this PM
+      raise Discourse::InvalidParameters.new(:pm_topic_id) unless (pm_topic && Guardian.new(current_user).can_see_topic?(pm_topic))
 
       # Validate whether badge should be awarded
-      award_badge = params[:award_badge] || false
-      raise Discourse::InvalidParameters.new(:title) unless ([true, false].include?(award_badge))
+      award_badge = to_bool(params[:award_badge])
+      raise Discourse::InvalidParameters.new(:award_badge) if (award_badge == nil)
 
-      if (params[:target_category_id] != nil)
+      could_post_on_own = (pm_topic.user.trust_level > SiteSetting.post_approval_redirect_tl_max)
+
+      post = nil # will contain the approved post
+      target_category = nil
+
+      if (!params[:target_category_id].blank?)
 
         # Validate target category for new topic
         target_category = Category.find_by(id: params[:target_category_id])
-        raise Discourse::InvalidParameters.new(:target_category_id) unless target_category
-
-        # TODO: need to validate that current_user can post in this category
+        raise Discourse::InvalidParameters.new(:target_category_id) unless (target_category && Guardian.new(current_user).can_move_topic_to_category?(target_category))
 
         # Validate title for the new topic
         title = params[:title]
@@ -42,9 +187,16 @@ after_initialize do
           title.length >= SiteSetting.min_topic_title_length && title.length <= SiteSetting.max_topic_title_length)
 
         # Validate tags for the new topic
-        tags = params[:tags] == nil ? [] : params[:tags]
+        tags = params[:tags]
+        if tags.blank?
+          tags = []
+        end
         raise Discourse::InvalidParameters.new(:tags) unless (tags.kind_of?(Array) &&
-          tags.select{|s| !s.instance_of?(String) || s.length == 0}.length > 0) # All strings, non-empty
+          tags.select{|s| !s.instance_of?(String) || s.length == 0}.length == 0) # All strings, non-empty
+
+        if Guardian.new(pm_topic.user).can_move_topic_to_category?(target_category)
+          could_post_on_own = true
+        end
 
         # Create the new topic in the target category
         post = PostCreator.create(
@@ -55,43 +207,91 @@ after_initialize do
           user: pm_topic.user,
           tags: tags,
           custom_fields: {
-            post_approval_finished: true # Make sure it triggers notifications
+            post_approval: true # TODO: does this work? Make sure it triggers notifications
           },
           skip_validations: true, # They've already gone through the validations to make the topic first
         )
 
-        # Complete the request
-        finalize(current_user, pm_topic, post, should_award_badge)
-
-      elsif (params[:target_topic_id] != nil)
+      elsif (!params[:target_topic_id].blank?)
 
         # Validate target existing topic for new reply
         target_topic = Topic.find_by(id: params[:target_topic_id], archetype: Archetype.default)
-        raise Discourse::InvalidParameters.new(:target_topic_id) unless target_topic
+        raise Discourse::InvalidParameters.new(:target_topic_id) unless (target_topic && Guardian.new(current_user).can_create_post_on_topic?(target_topic))
 
-        # TODO: need to validate that current_user can reply to this topic
+        target_category = Category.find_by(id: target_topic.category_id)
+
+        if Guardian.new(pm_topic.user).can_create_post_on_topic?(target_topic)
+          could_post_on_own = true
+        end
 
         # Create the new reply on the target topic
         post = PostCreator.create(
           pm_topic.user,
-          topic_id: pm_topic.id,
+          topic_id: target_topic.id,
           raw: pm_topic.posts.first.raw,
           user: pm_topic.user,
           custom_fields: {
-            post_approval_finished: true # Make sure it triggers notifications
+            post_approval: true # Make sure it triggers notifications
           },
           skip_validations: true, # They've already gone through the validations to make the reply first
         )
-
-        # Complete the request
-        finalize(current_user, pm_topic, post, should_award_badge)
 
       else
         raise Discourse::InvalidParameters.new() # Can't do both a new topic / a reply at once
       end
 
-      # No error encountered
-      render json: success_json
+      is_topic = post.is_first_post?
+
+      # Different entry text depending on whether it was a new topic / a reply
+      body = (is_topic ? SiteSetting.post_approval_response_topic : SiteSetting.post_approval_response_reply)
+
+      # Attempt awarding badge if applicable
+      if (award_badge && SiteSetting.post_approval_badge > 0)
+        badge = Badge.find_by(id: SiteSetting.post_approval_badge, enabled: true)
+
+        if badge
+          # Award the badge
+          BadgeGranter.grant(badge, post.user, post_id: post.id)
+
+          # Attach a note if the user achieved a badge through this post approval request
+          body += "\n\n" + SiteSetting.post_approval_response_badge
+            .gsub("%BADGE%", "[#{badge.name}](#{Discourse.base_url}/badges/#{badge.id}/#{badge.slug})")
+        end
+      end
+
+      # Attach a note if the user could have posted without post approval
+      if could_post_on_own
+        body += "\n\n" + (is_topic ? SiteSetting.post_approval_response_topic_footer : SiteSetting.post_approval_response_reply_footer)
+      end
+
+      # Format body depending on input post
+      body = body.gsub("%USER%", pm_topic.user.username)
+      body = body.gsub("%POST%", "#{Discourse.base_url}#{post.url}")
+      if target_category
+        body = body.gsub("%CATEGORY%", target_category.name)
+      end
+
+      # Send confirmation on private message
+      reply = PostCreator.create(
+        current_user,
+        topic_id: pm_topic.id,
+        raw: body,
+        skip_validations: true,
+      )
+
+      # Mark confirmation as solution of private message
+      if SiteSetting.solved_enabled
+        DiscourseSolved.accept_answer!(reply, current_user)
+      end
+
+      # Archive the private message
+      archive_message(pm_topic)
+
+      pm_topic.reload
+      pm_topic.save
+
+      # Complete the request
+      render json: { url: post.url }
     end
 
     # Archiving a private message
@@ -112,79 +312,34 @@ after_initialize do
         UserArchivedMessage.archive!(current_user.id, topic)
       end
     end
-
-    # Awarding the post approval badge for a post
-    def award_badge(post)
-      return unless SiteSetting.post_approval_finish_badge > 0 # not enabled
-      return unless badge = Badge.find_by(id: SiteSetting.post_approval_finish_badge, enabled: true) # no badge found
-
-      BadgeGranter.grant(badge, post.user, post_id: post.id)
-    end
-
-    # Whether post could have been posted without post approval
-    def could_post_on_own(post)
-
-      # TODO
-      
-      return false
-    end
-
-    # Getting the body for the final reply to the private message
-    def make_body(post, should_award_badge)
-
-      # Different entry text depending on whether it was a new topic / a reply
-      is_topic = post.is_first_post?
-      body = (is_topic ? SiteSetting.post_approval_finish_text_topic : SiteSetting.post_approval_finish_text_reply)
-
-      # Attach a note if the user achieved a badge through this post approval request
-      if should_award_badge
-        body += "\n\n" + SiteSetting.post_approval_finish_text_badge
-      end
-
-      # Attach a note if the user could have posted without post approval
-      if could_post_on_own(post)
-        body += "\n\n" + (is_topic ? SiteSetting.post_approval_finish_text_topic_footer : SiteSetting.post_approval_finish_text_reply_footer)
-      end
-
-    end
-
-    # Collection of actions to perform upon finalizing post approval
-    def finalize(current_user, pm_topic, post, should_award_badge)
-
-      # Award badge if applicable
-      award_badge(post) if should_award_badge
-
-      # Format body depending on input post
-      body = make_body(post, should_award_badge)
-        .gsub("%USER%", pm_topic.user.username)
-        .gsub("%POST%", post.url)
-      body = body.gsub("%CATEGORY%", post.category.name) if post.category
-
-      # Send confirmation on private message
-      reply = PostCreator.create(
-        current_user,
-        topic_id: pm_topic.id,
-        raw: body,
-        skip_validations: true,
-      )
-
-      # Mark confirmation as solution of private message
-      DiscourseSolved.accept_answer!(reply, current_user)
-
-      # Archive the private message
-      archive_message(pm_topic)
-
-      pm_topic.reload
-      pm_topic.save
-
-    end
   end
 
-  PostApprovalFinish::Engine.routes.draw do
-    post "/post-approval-finish" => "post_approval_finish#action"
+  # Routing
+
+  PostApproval::Engine.routes.draw do
+    post "/post-approval" => "post_approval#action"
   end
 
   Discourse::Application.routes.append do
-    mount ::PostApprovalFinish::Engine, at: "/"
+    mount ::PostApproval::Engine, at: "/"
   end
+
+  # Showing users whether they are post approval members
+
+  # TODO: are groups available already on the client? do we need this?
+  add_to_serializer(:current_user, :is_post_approval) {
+    # TODO: make sure this is the cheapest possible way to find out group membership,
+    # since this affects every page and every user
+    group = Group.find_by(name: SiteSetting.post_approval_button_group)
+
+    if group
+      GroupUser.where(group_id: Group.find_by(name: SiteSetting.post_approval_button_group).id)
+        .where(user_id: object.id)
+        .exists?
+    end
+  }
+  add_to_serializer(:current_user, :include_is_post_approval?) {
+    SiteSetting.post_approval_enabled && SiteSetting.post_approval_button_enabled
+  }
+
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -56,7 +56,7 @@ after_initialize do
           tags: tags,
           custom_fields: {
             post_approval_finished: true # Make sure it triggers notifications
-          }
+          },
           skip_validations: true, # They've already gone through the validations to make the topic first
         )
 
@@ -66,7 +66,7 @@ after_initialize do
       elsif (params[:target_topic_id] != nil)
 
         # Validate target existing topic for new reply
-        target_topic = Topic.find_by(id: params[:target_topic_id], Archetype.default)
+        target_topic = Topic.find_by(id: params[:target_topic_id], archetype: Archetype.default)
         raise Discourse::InvalidParameters.new(:target_topic_id) unless target_topic
 
         # TODO: need to validate that current_user can reply to this topic
@@ -79,7 +79,7 @@ after_initialize do
           user: pm_topic.user,
           custom_fields: {
             post_approval_finished: true # Make sure it triggers notifications
-          }
+          },
           skip_validations: true, # They've already gone through the validations to make the reply first
         )
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -69,7 +69,7 @@ after_initialize do
         SiteSetting.post_approval_redirect_group.present? &&
         !(topic.custom_fields["post_approval"]) && # TODO: test+fix this, custom marker to fall-through
         topic.user&.trust_level <= SiteSetting.post_approval_redirect_tl_max &&
-        topic.category&.pa_redirect_topic_enableds
+        topic.category&.pa_redirect_topic_enabled
     end
     module_function :is_redirectable
 

--- a/spec/integration/post_approval_finish_spec.rb
+++ b/spec/integration/post_approval_finish_spec.rb
@@ -60,10 +60,10 @@ RSpec.describe "Post Approval Finish" do
     end
 
     before do
-      SiteSetting.post_approval_finish_enabled = true
-      SiteSetting.post_approval_finish_group = "Gatekeepers"
-      SiteSetting.post_approval_finish_from_category = category.id
-      SiteSetting.post_approval_finish_topic_template = "great post:%USER%/%CATEGORYNAME%/%TOPICLINK%"
+      SiteSetting.post_approval_enabled = true
+      SiteSetting.post_approval_group = "Gatekeepers"
+      SiteSetting.post_approval_from_category = category.id
+      SiteSetting.post_approval_topic_template = "great post:%USER%/%CATEGORYNAME%/%TOPICLINK%"
     end
 
     context "while logged in as a sage" do
@@ -81,7 +81,7 @@ RSpec.describe "Post Approval Finish" do
           post_action_type_id: PostActionType.types[:like],
         ).count).to eq(2)
 
-        post "/post-approval-finish.json", params: {
+        post "/post-approval", params: {
           bb_topic_id: pa[:bb_topic].id,
           pm_topic_id: pa[:pm_topic].id,
           category_id: open_category.id,
@@ -122,7 +122,7 @@ RSpec.describe "Post Approval Finish" do
       it "should deny" do
         pa = create_pa()
 
-        post "/post-approval-finish.json", params: {
+        post "/post-approval", params: {
           bb_topic_id: pa[:bb_topic].id,
           pm_topic_id: pa[:pm_topic].id,
           category_id: open_category.id,


### PR DESCRIPTION
Complete version that handles everything about post approval.

Remaining TODOs:
- Prediction of initial values for post approval move window on front-end
- Suppressing notifications when post is about to be redirected (both for replies and new topics)
- Check whether :is_post_approval serializer is performant

Future (soontm?):
- There are settings to also redirect replies on a category now, but still need to implement the actual logic behind this. (most of the code already supports post approval for replies, it's just the redirecting part + suppressing notifications on new replies (similar to suppressing notifs for new topics))