### PR TITLE
Update is_group_name to compare lowercase names

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -1,5 +1,5 @@
 # name: post-approval
-# version: 0.5.1
+# version: 0.5.2
 # authors: buildthomas, boyned/Kampfkarren
 
 enabled_site_setting :post_approval_enabled

--- a/plugin.rb
+++ b/plugin.rb
@@ -82,8 +82,8 @@ after_initialize do
   module PostApprovalHelper
     def self.is_group_name?(group_name)
       SiteSetting.post_approval_enabled &&
-        (group_name == SiteSetting.post_approval_redirect_topic_group ||
-         group_name == SiteSetting.post_approval_redirect_reply_group)
+        (group_name.downcase == SiteSetting.post_approval_redirect_topic_group.downcase ||
+         group_name.downcase == SiteSetting.post_approval_redirect_reply_group.downcase)
     end
 
     def self.is_redirect_topics_enabled


### PR DESCRIPTION
Ordering the inbox from oldest to newest would break if you clicked on a notification for the PA inbox, because it'd link to `messages/group/post_approval` instead of `messages/group/Post_Approval`. post_approval isn't the same as the site setting Post_Approval so the check would return false.

I couldn't find any issues when I tested it (tested for character collisions, using a similar Post.Approval group, etc). The function is used to order the inbox and when redirecting posts to the inbox. Both seemed to work fine.